### PR TITLE
Ugprade `github-branch-source` to 1844.v4a_9883d49126

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.8</version>
+    <version>1.10</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>7.3.1-258.v6f931956b_791</version>
+      <version>7.3.1-256.v788a_0b_787114</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -45,8 +45,8 @@
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <junit5.version>5.10.0</junit5.version>
   </properties>
 
@@ -80,7 +80,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3696.vb_b_4e2d1a_0542</version>
+        <version>3944.v1a_e4f8b_452db_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,16 +103,6 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>openstack-cloud</artifactId>
         <version>1456.v1c7380506a_ed</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.github.stephenc.findbugs</groupId>
-            <artifactId>findbugs-annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.datapipe.jenkins.plugins</groupId>
@@ -157,14 +147,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>openstack-cloud</artifactId>
-      <!-- https://github.com/jenkinsci/openstack-cloud-plugin/issues/367 -->
-      <exclusions>
-        <exclusion>
-          <!-- from snakeyaml-api -->
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-        </exclusion>
-      </exclusions>
       <optional>true</optional>
     </dependency>
       <!-- Basic Username PrivateKey -->

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,7 @@
         <!-- TODO: Remove when included in BOM -->
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>github-branch-source</artifactId>
-        <!-- TODO: https://github.com/jenkinsci/github-branch-source-plugin/pull/822 -->
-        <version>1811.v7a_30947374b_3</version>
+        <version>1844.v4a_9883d49126</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.7</version>
+    <version>5.17</version>
     <relativePath />
   </parent>
 
@@ -45,7 +45,7 @@
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <junit5.version>5.12.2</junit5.version>
   </properties>
@@ -80,7 +80,8 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <!-- ensure okhttp-bom is aligned when this is updated -->
+        <version>4710.v016f0a_07e34d</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-    <junit5.version>5.10.0</junit5.version>
+    <junit5.version>5.12.2</junit5.version>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-    <junit5.version>5.12.2</junit5.version>
+    <junit5.version>5.13.2</junit5.version>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>6.14.0-255.v44e4b_386fb_a_e</version>
+      <version>7.3.1-258.v6f931956b_791</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
-      <version>6.14.0</version>
+      <version>7.3.1</version>
       <scope>test</scope>
       <exclusions>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>openstack-cloud</artifactId>
-        <version>2.63</version>
+        <version>2.66</version>
         <exclusions>
           <exclusion>
             <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>6.14.0-255.va_8c7a_67b_2f79</version>
+      <version>6.14.0-255.v44e4b_386fb_a_e</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>openstack-cloud</artifactId>
-        <version>2.66</version>
+        <version>1456.v1c7380506a_ed</version>
         <exclusions>
           <exclusion>
             <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,16 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <!-- ensure okhttp-bom is aligned when this is updated -->
-        <version>4710.v016f0a_07e34d</version>
+        <version>4924.v6b_eb_a_79a_d9d0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+    <!-- Remove jackson when on bom -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.19.0-404.vb_b_0fd2fea_e10</version>
+    </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp-bom</artifactId>
@@ -122,6 +128,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
+      <version>6.14.0-255.va_8c7a_67b_2f79</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -193,7 +200,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
-      <version>6.10.0</version>
+      <version>6.14.0</version>
       <scope>test</scope>
       <exclusions>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -81,16 +81,10 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <!-- ensure okhttp-bom is aligned when this is updated -->
-        <version>4924.v6b_eb_a_79a_d9d0</version>
+        <version>5015.vb_52d36583443</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-    <!-- Remove jackson when on bom -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-      <version>2.19.0-404.vb_b_0fd2fea_e10</version>
-    </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp-bom</artifactId>
@@ -128,7 +122,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>kubernetes-client-api</artifactId>
-      <version>7.3.1-256.v788a_0b_787114</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/KubernetesCredentialsProviderTest.java
@@ -53,6 +53,7 @@ public class KubernetesCredentialsProviderTest {
     private static final Long EVENT_WAIT_PERIOD_MS = 10L;
 
     private KubernetesMockServer server;
+    private KubernetesClient client;
     private @Mock ScheduledExecutorService jenkinsTimer;
 
     private @Mock(answer = Answers.CALLS_REAL_METHODS) MockedStatic<ExtensionList> extensionList;
@@ -63,6 +64,7 @@ public class KubernetesCredentialsProviderTest {
         server = new KubernetesMockServer();
         server.init();
         server.clearExpectations();
+        client = server.createClient();
         // mocked to validate add/remove of administrative errors
         ExtensionList<AdministrativeMonitor> monitors = ExtensionList.create((Jenkins) null, AdministrativeMonitor.class);
         // mocked to validate start watching for secrets
@@ -75,6 +77,7 @@ public class KubernetesCredentialsProviderTest {
 
     @After
     public void tearDown() {
+        client.close();
         server.destroy();
     }
 
@@ -351,7 +354,7 @@ public class KubernetesCredentialsProviderTest {
     private class MockedKubernetesCredentialProvider extends KubernetesCredentialProvider {
         @Override
         KubernetesClient getKubernetesClient() {
-            return server.createClient();
+            return client;
         }
     }
 }


### PR DESCRIPTION
Hi @dwnusbaum!

This upgrades `github-branch-source` to [1844.v4a_9883d49126](https://github.com/jenkinsci/github-branch-source-plugin/releases/tag/1844.v4a_9883d49126) and update to `master` branch.

`mvn clean install` runs successfully locally.